### PR TITLE
Bump to 3.3.0: update dependencies for Vaadin 24.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>treecombobox</artifactId>
-    <version>3.2.0</version>
+    <version>3.3.0</version>
     <name>TreeComboBox</name>
     <description>ComboBox with hierarchy</description>
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <vaadin.version>24.2.2</vaadin.version>
+        <vaadin.version>24.3.15</vaadin.version>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -88,12 +88,12 @@
         <dependency>
             <groupId>com.vaadin.componentfactory</groupId>
             <artifactId>popup</artifactId>
-            <version>24.0.4</version>
+            <version>24.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.vaadin.tatu</groupId>
             <artifactId>tree</artifactId>
-            <version>3.2.0</version>
+            <version>3.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.4.1</version>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- Bump add-on version from 3.2.0 to 3.3.0
- Update Vaadin from 24.2.2 to 24.3.15
- Update `org.vaadin.tatu:tree` from 3.2.0 to 3.3.0 (adds keyboard navigation support)
- Update `com.vaadin.componentfactory:popup` from 24.0.4 to 24.0.5
- Update `webdrivermanager` from 5.4.1 to 5.7.0

These changes match the published 3.3.0 release on Maven Central / Vaadin Directory, whose source was not previously committed to this repository.

## Test plan
- [ ] `mvn clean install -DskipTests` compiles successfully
- [ ] Existing demo/test applications work with Vaadin 24.3.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)